### PR TITLE
Updating gross_unit_price when a price list has '0.00' as formula

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -20,15 +20,16 @@ class Sale(metaclass=PoolMeta):
         with Transaction().set_context(line._get_context_sale_price()):
             unit_price = Product.get_sale_price([line.product],
                     line.quantity or 0)[line.product.id]
-            if unit_price:
-                if hasattr(line, 'gross_unit_price'):
-                    gross_unit_price = round_price(unit_price)
-                    if line.discount:
-                        unit_price_discount = (
-                                unit_price * (Decimal(1) - line.discount))
-                        unit_price = unit_price_discount
-                    values['gross_unit_price'] = gross_unit_price
-            values['unit_price'] = round_price(unit_price or Decimal(0))
+            if not unit_price:
+                unit_price = Decimal(0)
+            if hasattr(line, 'gross_unit_price'):
+                gross_unit_price = round_price(unit_price)
+                if line.discount:
+                    unit_price_discount = (
+                            unit_price * (Decimal(1) - line.discount))
+                    unit_price = unit_price_discount
+                values['gross_unit_price'] = gross_unit_price
+            values['unit_price'] = round_price(unit_price)
 
         return values
 

--- a/sale.py
+++ b/sale.py
@@ -20,16 +20,15 @@ class Sale(metaclass=PoolMeta):
         with Transaction().set_context(line._get_context_sale_price()):
             unit_price = Product.get_sale_price([line.product],
                     line.quantity or 0)[line.product.id]
-            if not unit_price:
-                unit_price = Decimal(0)
-            if hasattr(line, 'gross_unit_price'):
-                gross_unit_price = round_price(unit_price)
-                if line.discount:
-                    unit_price_discount = (
-                            unit_price * (Decimal(1) - line.discount))
-                    unit_price = unit_price_discount
-                values['gross_unit_price'] = gross_unit_price
-            values['unit_price'] = round_price(unit_price)
+            if unit_price is not None:
+                if hasattr(line, 'gross_unit_price'):
+                    gross_unit_price = round_price(unit_price)
+                    if line.discount:
+                        unit_price_discount = (
+                                unit_price * (Decimal(1) - line.discount))
+                        unit_price = unit_price_discount
+                    values['gross_unit_price'] = gross_unit_price
+            values['unit_price'] = round_price(unit_price or Decimal(0))
 
         return values
 


### PR DESCRIPTION
The purpose is to update the sale line gross unit price, when a price list defines this product cost as 0.
Not updating the gross unit price in those cases, not only creates visual unexpected behaviour to the users, also creates some inconsistence, as the `sale_discount` module calls `Sale.apply_discount_to_lines()` in `Sale.write()`, every change on the sale modifies the line unit price.